### PR TITLE
Fix npm No repository field warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "keywords": [
     "font"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FontFaceKit/open-sans"
+  },
   "license": "Apache License version 2.0",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Thanks for the work on FontFaceKit/open-sans.
This is a minor fix to avoid the warnings triggered by `npm`.
I added your package to mine using:

```
npm install git://github.com/FontFaceKit/open-sans.git#gh-pages --save
```

but any subsequent calls to `npm` now displays this:

```
npm WARN package.json open-sans-fontface@1.2.1 No repository field.
```

this PR fixes that issue.

Thank you.
Maybe you will consider submitting your package to npm?
https://docs.npmjs.com/misc/developers
http://evanhahn.com/make-an-npm-baby/
