### PR TITLE
Fix semibold font paths for open-sans.less

### DIFF
--- a/open-sans.less
+++ b/open-sans.less
@@ -58,7 +58,7 @@
 @font-face {
   font-family: 'Open Sans';
   src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold2.eot');
-  src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.eot?#iefix') format('embedded-opentype'),
+  src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold2.eot?#iefix') format('embedded-opentype'),
        url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.woff') format('woff'),
        url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.ttf') format('truetype'),
        url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.svg#OpenSansSemibold') format('svg');

--- a/open-sans.less
+++ b/open-sans.less
@@ -57,7 +57,7 @@
 /* BEGIN Semibold */
 @font-face {
   font-family: 'Open Sans';
-  src: url('@{OpenSansPath}/Semibold/OpenSans-Semibold.eot');
+  src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold2.eot');
   src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.eot?#iefix') format('embedded-opentype'),
        url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.woff') format('woff'),
        url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.ttf') format('truetype'),

--- a/open-sans.less
+++ b/open-sans.less
@@ -58,10 +58,10 @@
 @font-face {
   font-family: 'Open Sans';
   src: url('@{OpenSansPath}/Semibold/OpenSans-Semibold.eot');
-  src: url('@{OpenSansPath}/Semibold/OpenSans-Semibold.eot?#iefix') format('embedded-opentype'),
-       url('@{OpenSansPath}/Semibold/OpenSans-Semibold.woff') format('woff'),
-       url('@{OpenSansPath}/Semibold/OpenSans-Semibold.ttf') format('truetype'),
-       url('@{OpenSansPath}/Semibold/OpenSans-Semibold.svg#OpenSansSemibold') format('svg');
+  src: url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.eot?#iefix') format('embedded-opentype'),
+       url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.woff') format('woff'),
+       url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.ttf') format('truetype'),
+       url('@{OpenSansPath}/SemiBold/OpenSans-SemiBold.svg#OpenSansSemibold') format('svg');
   font-weight: 600;
   font-style: normal;
 }
@@ -70,11 +70,11 @@
 /* BEGIN Semibold Italic */
 @font-face {
   font-family: 'Open Sans';
-  src: url('@{OpenSansPath}/SemiboldItalic/OpenSans-SemiboldItalic.eot');
-  src: url('@{OpenSansPath}/SemiboldItalic/OpenSans-SemiboldItalic.eot?#iefix') format('embedded-opentype'),
-       url('@{OpenSansPath}/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff'),
-       url('@{OpenSansPath}/SemiboldItalic/OpenSans-SemiboldItalic.ttf') format('truetype'),
-       url('@{OpenSansPath}/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic') format('svg');
+  src: url('@{OpenSansPath}/SemiBoldItalic/OpenSans-SemiBoldItalic.eot');
+  src: url('@{OpenSansPath}/SemiBoldItalic/OpenSans-SemiBoldItalic.eot?#iefix') format('embedded-opentype'),
+       url('@{OpenSansPath}/SemiBoldItalic/OpenSans-SemiBoldItalic.woff') format('woff'),
+       url('@{OpenSansPath}/SemiBoldItalic/OpenSans-SemiBoldItalic.ttf') format('truetype'),
+       url('@{OpenSansPath}/SemiBoldItalic/OpenSans-SemiBoldItalic.svg#OpenSansSemiboldItalic') format('svg');
   font-weight: 600;
   font-style: italic;
 }


### PR DESCRIPTION
Font names and paths were recently changed from Semibold to SemiBold (and SemiboldItalic to SemiBoldItalic). However, open-sans.less was not updated to reflect the changes. This pull request fixes open-sans.less to reflect updated paths and font names.